### PR TITLE
add a new function decompressFromUint8Array 

### DIFF
--- a/lzstring.py
+++ b/lzstring.py
@@ -5,7 +5,9 @@ terms of the Do What The Fuck You Want To Public License, Version 2,
 as published by Sam Hocevar. See the COPYING file for more details.
 """
 
+from bz2 import decompress
 import math
+from typing_extensions import Self
 
 
 keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
@@ -423,3 +425,14 @@ class LZString(object):
             return None
         compressed = compressed.replace(" ", "+")
         return _decompress(len(compressed), 32, lambda index: getBaseValue(keyStrUriSafe, compressed[index]))
+    
+    @staticmethod
+    def decompressFromUint8Array(compressed):
+        length_compressed = len(compressed)//2
+        buf=[]
+        for i in range(length_compressed):
+            buf.append(compressed[i*2]*256+compressed[i*2+1])
+        result=[]
+        for i in buf:
+            result.append(chr(i & 0xffff))
+        return decompress(''.join(result))

--- a/lzstring.py
+++ b/lzstring.py
@@ -5,9 +5,7 @@ terms of the Do What The Fuck You Want To Public License, Version 2,
 as published by Sam Hocevar. See the COPYING file for more details.
 """
 
-from bz2 import decompress
 import math
-from typing_extensions import Self
 
 
 keyStrBase64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="


### PR DESCRIPTION
There was no function decompressFromUint8Array compared with the JS version, so I added a new one in class LZString, maybe will be useful.